### PR TITLE
Reorganize types

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,0 +1,1 @@
+/types/EslintIgnore.d.ts

--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 node_modules
+/types/test.ts

--- a/types/Array.d.ts
+++ b/types/Array.d.ts
@@ -8,7 +8,7 @@ interface ArrayLike<T> {
 	 * This field exists to force TypeScript to recognize this as a nominal type
 	 * @deprecated
 	 */
-	readonly _arrayBrand: unique symbol;
+	readonly _nominal_Array: unique symbol;
 
 	/**
 	 * Gets the length of the array. This is one higher than the highest index defined in an array.

--- a/types/EslintIgnore.d.ts
+++ b/types/EslintIgnore.d.ts
@@ -1,0 +1,3 @@
+// this file uses features that eslint doesn't like :(
+
+type NonNominalKeys<T> = { [K in keyof T]: K extends `_nominal_${infer _U}` ? never : K }[keyof T];

--- a/types/EslintIgnore.d.ts
+++ b/types/EslintIgnore.d.ts
@@ -1,3 +1,4 @@
 // this file uses features that eslint doesn't like :(
 
-type NonNominalKeys<T> = { [K in keyof T]: K extends `_nominal_${infer _U}` ? never : K }[keyof T];
+/** Returns a union of all the keys of T which do not start with `_nominal_` */
+type ExcludeNominalKeys<T> = { [K in keyof T]: K extends `_nominal_${infer _U}` ? never : K }[keyof T];

--- a/types/Map.d.ts
+++ b/types/Map.d.ts
@@ -29,7 +29,7 @@ interface ReadonlyMap<K, V> extends Iterable<[K, V]> {
 	 * This field exists to force TypeScript to recognize this as a nominal type
 	 * @deprecated
 	 */
-	readonly _mapBrand: unique symbol;
+	readonly _nominal_Map: unique symbol;
 
 	/**
 	 * Returns true if empty, otherwise false.

--- a/types/Set.d.ts
+++ b/types/Set.d.ts
@@ -8,7 +8,7 @@ interface ReadonlySet<T> extends Iterable<T> {
 	 * This field exists to force TypeScript to recognize this as a nominal type
 	 * @deprecated
 	 */
-	readonly _setBrand: unique symbol;
+	readonly _nominal_Set: unique symbol;
 
 	/**
 	 * Returns true if empty, otherwise false.

--- a/types/callMacros.d.ts
+++ b/types/callMacros.d.ts
@@ -45,17 +45,7 @@ declare function opcall<T extends Array<any>, U>(
  * @param instance
  * @param className
  */
-declare function classIs<
-	T extends Instance,
-	Q extends Extract<T["ClassName"], Exclude<keyof Instances, keyof AbstractInstances>>
->(
-	instance: T,
-	className: Q,
-): instance is Instances[Q] extends T
-	? Instances[Q]["ClassName"] extends Q
-		? Instances[Q]
-		: Instances[Q] & { ClassName: Q }
-	: T;
+declare function classIs<T extends keyof Instances>(instance: Instance, className: T): instance is Instances[T];
 
 /**
  * Returns the passed argument.

--- a/types/core.d.ts
+++ b/types/core.d.ts
@@ -11,28 +11,49 @@
 /// <reference path="Symbol.d.ts" />
 /// <reference path="typeUtils.d.ts" />
 
-/** unknown - undefined = defined */
-type defined = {};
-
 /**
  * **DO NOT USE!** This type only exists because TypeScript requires it!
  *
  * **Use `boolean` instead!**
  */
 interface Boolean {}
-/** **DO NOT USE!** This type only exists because TypeScript requires it! */
+
+/**
+ * **DO NOT USE!**
+ *
+ * This type only exists because TypeScript requires it!
+ * @deprecated
+ */
 interface IArguments {}
+
 /**
  * **DO NOT USE!** This type only exists because TypeScript requires it!
  *
  * **Use `number` instead!**
+ * @deprecated
  */
 interface Number {}
-interface Object {}
-/** **DO NOT USE!** This type only exists because TypeScript requires it! */
-interface RegExp {}
+
 /**
  * **DO NOT USE!** This type only exists because TypeScript requires it!
+ *
+ * **Use `number` instead!**
+ * @deprecated
+ */
+interface Object {}
+
+/**
+ * **DO NOT USE!**
+ *
+ * This type only exists because TypeScript requires it!
+ * @deprecated
+ */
+interface RegExp {}
+
+/**
+ * **DO NOT USE!**
+ *
+ * This type only exists because TypeScript requires it!
  *
  * **Use the arrow function form instead!**
  *
@@ -43,14 +64,30 @@ interface RegExp {}
  * the return type.
  *
  * You can use `void` as a return type for functions that do not return anything: `() => void`
+ * @deprecated
  */
 interface Function {
 	prototype: never;
 }
-/** **DO NOT USE!** This type only exists because TypeScript requires it! */
+
+/**
+ * **DO NOT USE!**
+ *
+ * This type only exists because TypeScript requires it!
+ * @deprecated
+ */
 interface CallableFunction extends Function {}
-/** **DO NOT USE!** This type only exists because TypeScript requires it! */
+
+/**
+ * **DO NOT USE!**
+ *
+ * This type only exists because TypeScript requires it!
+ * @deprecated
+ */
 interface NewableFunction extends Function {}
+
+/** unknown - undefined = defined */
+type defined = {};
 
 /** Marker for contextual 'this' type */
 interface ThisType<T> {}
@@ -59,94 +96,3 @@ interface ThisType<T> {}
 type Callback = (...args: Array<any>) => any;
 
 type LuaTuple<T extends Array<any>> = T & { readonly LUA_TUPLE: never };
-
-type FilterMembers<T, U> = Pick<T, { [K in keyof T]: T[K] extends U ? K : never }[keyof T]>;
-
-/** Similar to Pick, but instead turns excluded values to undefined (so they can still be browsed) */
-type PresentFields<T, K extends keyof T> = { [P in keyof T]: P extends K ? T[P] : undefined };
-
-/** When a member (M) of T is a particular Value (E), Pick<K> */
-type FieldsPresentWhen<T, M extends keyof T, E extends T[M], K extends keyof T> = {
-	[P in keyof T]: P extends M ? E : P extends K ? T[P] : undefined;
-};
-
-/** Given an object `T`, returns a unioned type of all non-readonly property names. */
-type WritableProperties<T> = {
-	[K in keyof T]-?: T[K] extends Callback
-		? never
-		: (<F>() => F extends { [Q in K]: T[K] } ? 1 : 2) extends <F>() => F extends {
-				-readonly [Q in K]: T[K];
-		  }
-				? 1
-				: 2
-		? K
-		: never;
-}[keyof T];
-
-/** Given an object `T`, returns a partial object definition containing only the writable properties of `T` */
-type PartialProperties<T> = Partial<Pick<T, WritableProperties<T>>>;
-
-/** A mapping between Instance ClassNames and corresponding types with `ClassName` narrowed, if necessary.
- * For example, A `Part` type could mean a `SpawnLocation`, a `Seat`, or an object whose ClassName is "Part".
- * Thus, `StrictInstances["Part"]` gives `Part & { ClassName: "Part" }` for when you want a `Part` whose ClassName is "Part".
- */
-type StrictInstances = {
-	[K in Exclude<keyof Instances, keyof AbstractInstances>]: Instances[K] &
-		(Instances[K]["ClassName"] extends K ? unknown : { ClassName: K });
-};
-
-/** For a given Instance type (with intersections) this returns the type without intersections. */
-type OriginalInstanceType<T extends Instance> = T extends any
-	? T["ClassName"] extends infer A
-		? T["ClassName"] extends infer B
-			? (A extends any ? (B extends A ? true : false) : never) extends true
-				? A extends keyof Instances
-					? Instances[A] // Grab our raw ClassName if there is only one possibility (either StrictInstance or classes which are not superclasses for anything)
-					: never
-				: Instances[{
-						// Otherwise, iterate through Instances and grab the class with the "ClassName" property which matches T's exactly
-						[K in keyof Instances]: T["ClassName"] extends Instances[K]["ClassName"]
-							? Instances[K]["ClassName"] extends T["ClassName"]
-								? K
-								: never
-							: never;
-				  }[keyof Instances]]
-			: never
-		: never
-	: never;
-
-/** Given an Instance `T`, returns a unioned type of all property names, except "ClassName". */
-type InstanceProperties<I extends Instance> = OriginalInstanceType<I> extends infer T
-	? {
-			[K in keyof T]-?: K extends "ClassName" | "Changed" | "BreakJoints" | "MakeJoints"
-				? never
-				: T[K] extends RBXScriptSignal | Callback
-				? never
-				: K;
-	  }[keyof T]
-	: never;
-
-/** Given an Instance `T`, returns a unioned type of all non-readonly property names. */
-type WritableInstanceProperties<I extends Instance> = Extract<WritableProperties<OriginalInstanceType<I>>, keyof I>;
-
-/** Given an Instance `T`, returns an object which can hold the writable properties of T. Good to use with `Object.assign`.
- * @example
- * const props: PartialInstance<Part> = {
- * 	Size: new Vector3(),
- * 	Anchored: false,
- * }
- *
- * Object.assign(new Instance("Part"), props);
- */
-type PartialInstance<T extends Instance> = Partial<Pick<T, WritableInstanceProperties<T>>>;
-
-// temporary backwards compatibility:
-
-/** @deprecated */
-type GetProperties<T extends Instance> = InstanceProperties<T>;
-
-/** @deprecated */
-type GetWritableProperties<T extends Instance> = WritableInstanceProperties<T>;
-
-/** Returns a given objects parameters in a tuple. Defaults to `[]` */
-type FunctionArguments<T> = T extends (...args: infer U) => void ? U : [];

--- a/types/typeUtils.d.ts
+++ b/types/typeUtils.d.ts
@@ -32,6 +32,12 @@ type Exclude<T, U> = T extends U ? never : T;
 /** Extract from T those types that are assignable to U */
 type Extract<T, U> = T extends U ? T : never;
 
+/** Returns a union of all the keys of T whose values extend from U */
+type FilterKeys<T, U> = { [K in keyof T]: T[K] extends U ? K : never }[keyof T];
+
+/** Returns a new object type of all the keys of T whose values extend from U */
+type FilterMembers<T, U> = Pick<T, FilterKeys<T, U>>;
+
 /** Exclude null and undefined from T */
 type NonNullable<T> = unknown extends T ? defined : T extends null | undefined ? never : T;
 
@@ -50,7 +56,7 @@ type InstanceType<T extends new (...args: Array<any>) => any> = T extends new (.
 	: any;
 
 /** Combines a series of intersections into one object, e.g. { x: number } & { y: number } becomes { x: number, y: number } */
-type Reconstruct<T> = _<{ [k in keyof T]: T[k] }>;
+type Reconstruct<T> = _<{ [K in keyof T]: T[K] }>;
 
 /** Converts a series of object unions to a series of intersections, e.g. A | B becomes A & B */
 type UnionToIntersection<U> = (U extends object ? (k: U) => void : never) extends (k: infer I) => void ? I : never;
@@ -82,15 +88,10 @@ type WritablePropertyNames<T> = {
 type WritableProperties<T> = Pick<T, WritablePropertyNames<T>>;
 
 /** Given an Instance `T`, returns a unioned type of all property names, except "ClassName". */
-type InstancePropertyNames<I extends Instance> = I extends infer T
-	? {
-			[K in keyof T]-?: K extends "ClassName" | "Changed" | "BreakJoints" | "MakeJoints"
-				? never
-				: T[K] extends RBXScriptSignal | Callback
-				? never
-				: K;
-	  }[keyof T]
-	: never;
+type InstancePropertyNames<T extends Instance> = Exclude<
+	keyof T,
+	FilterKeys<T, RBXScriptSignal | Callback> | "ClassName" | "Changed" | "BreakJoints" | "MakeJoints"
+>;
 
 /** Given an Instance `T`, returns an object with methods and events filtered out. */
 type InstanceProperties<T extends Instance> = Pick<T, InstancePropertyNames<T>>;

--- a/types/typeUtils.d.ts
+++ b/types/typeUtils.d.ts
@@ -63,3 +63,36 @@ type OmitThisParameter<T> = unknown extends ThisParameterType<T>
 	: T extends (...args: infer A) => infer R
 	? (...args: A) => R
 	: T;
+
+/** Given an object `T`, returns a unioned type of all non-readonly property names. */
+type WritablePropertyNames<T> = {
+	[K in keyof T]-?: T[K] extends Callback
+		? never
+		: (<F>() => F extends { [Q in K]: T[K] } ? 1 : 2) extends <F>() => F extends {
+				-readonly [Q in K]: T[K];
+		  }
+				? 1
+				: 2
+		? K
+		: never;
+}[keyof T];
+
+/** Given an object `T`, returns an object with readonly fields filtered out. */
+type WritableProperties<T> = Pick<T, WritablePropertyNames<T>>;
+
+/** Given an Instance `T`, returns a unioned type of all property names, except "ClassName". */
+type InstancePropertyNames<I extends Instance> = I extends infer T
+	? {
+			[K in keyof T]-?: K extends "ClassName" | "Changed" | "BreakJoints" | "MakeJoints"
+				? never
+				: T[K] extends RBXScriptSignal | Callback
+				? never
+				: K;
+	  }[keyof T]
+	: never;
+
+/** Given an Instance `T`, returns an object with methods and events filtered out. */
+type InstanceProperties<T extends Instance> = Pick<T, InstancePropertyNames<T>>;
+
+/** Given an Instance `T`, returns an object with readonly fields, methods, and events filtered out. */
+type WritableInstanceProperties<T extends Instance> = WritableProperties<InstanceProperties<T>>;

--- a/types/typeUtils.d.ts
+++ b/types/typeUtils.d.ts
@@ -93,16 +93,26 @@ type WritablePropertyNames<T> = {
 /** Given an object `T`, returns an object with readonly fields filtered out. */
 type WritableProperties<T> = Pick<T, WritablePropertyNames<T>>;
 
-/** Given an Instance `T`, returns a unioned type of all property names, except "ClassName". */
-type InstancePropertyNames<T extends Instance> = Exclude<
-	keyof T,
-	ExtractKeys<T, RBXScriptSignal | Callback | symbol> | "ClassName" | "Changed" | "BreakJoints" | "MakeJoints"
->;
+/** Given an Instance `T`, returns a unioned type of all property names. */
+type InstancePropertyNames<T extends Instance> = ExcludeKeys<T, RBXScriptSignal | Callback | symbol>;
 
-/** Given an Instance `T`, returns an object with methods and events filtered out. */
+/** Given an Instance `T`, returns a unioned type of all method names. */
+type InstanceMethodNames<T extends Instance> = ExtractKeys<T, Callback>;
+
+/** Given an Instance `T`, returns a unioned type of all event names. */
+type InstanceEventNames<T extends Instance> = ExtractKeys<T, RBXScriptSignal>;
+
+/** Given an Instance `T`, returns an object with only properties. */
 type InstanceProperties<T extends Instance> = Pick<T, InstancePropertyNames<T>>;
+
+/** Given an Instance `T`, returns an object with only methods. */
+type InstanceMethods<T extends Instance> = Pick<T, InstanceMethodNames<T>>;
+
+/** Given an Instance `T`, returns an object with only events. */
+type InstanceEvents<T extends Instance> = Pick<T, InstanceEventNames<T>>;
 
 /** Given an Instance `T`, returns an object with readonly fields, methods, and events filtered out. */
 type WritableInstanceProperties<T extends Instance> = WritableProperties<InstanceProperties<T>>;
 
-type FilterNominalTags<T> = Pick<T, NonNominalKeys<T>>;
+/** Returns a new object type of all the keys of T which do not start with `_nominal_` */
+type ExcludeNominalMembers<T> = Pick<T, ExcludeNominalKeys<T>>;

--- a/types/typeUtils.d.ts
+++ b/types/typeUtils.d.ts
@@ -1,5 +1,6 @@
 /// <reference no-default-lib="true"/>
 /// <reference types="@rbxts/types"/>
+/// <reference path="EslintIgnore.d.ts" />
 
 /** Placeholder that sometimes helps force TS to display what you want it to. */
 type _<T> = T;
@@ -96,3 +97,5 @@ type InstanceProperties<T extends Instance> = Pick<T, InstancePropertyNames<T>>;
 
 /** Given an Instance `T`, returns an object with readonly fields, methods, and events filtered out. */
 type WritableInstanceProperties<T extends Instance> = WritableProperties<InstanceProperties<T>>;
+
+type FilterNominalTags<T> = Pick<T, NonNominalKeys<T>>;

--- a/types/typeUtils.d.ts
+++ b/types/typeUtils.d.ts
@@ -33,10 +33,16 @@ type Exclude<T, U> = T extends U ? never : T;
 type Extract<T, U> = T extends U ? T : never;
 
 /** Returns a union of all the keys of T whose values extend from U */
-type FilterKeys<T, U> = { [K in keyof T]: T[K] extends U ? K : never }[keyof T];
+type ExtractKeys<T, U> = { [K in keyof T]: T[K] extends U ? K : never }[keyof T];
 
 /** Returns a new object type of all the keys of T whose values extend from U */
-type FilterMembers<T, U> = Pick<T, FilterKeys<T, U>>;
+type ExtractMembers<T, U> = Pick<T, ExtractKeys<T, U>>;
+
+/** Returns a union of all the keys of T whose values do not extend from U */
+type ExcludeKeys<T, U> = { [K in keyof T]: T[K] extends U ? never : K }[keyof T];
+
+/** Returns a new object type of all the keys of T whose values do not extend from U */
+type ExcludeMembers<T, U> = Pick<T, ExcludeKeys<T, U>>;
 
 /** Exclude null and undefined from T */
 type NonNullable<T> = unknown extends T ? defined : T extends null | undefined ? never : T;

--- a/types/typeUtils.d.ts
+++ b/types/typeUtils.d.ts
@@ -96,7 +96,7 @@ type WritableProperties<T> = Pick<T, WritablePropertyNames<T>>;
 /** Given an Instance `T`, returns a unioned type of all property names, except "ClassName". */
 type InstancePropertyNames<T extends Instance> = Exclude<
 	keyof T,
-	ExtractKeys<T, RBXScriptSignal | Callback> | "ClassName" | "Changed" | "BreakJoints" | "MakeJoints"
+	ExtractKeys<T, RBXScriptSignal | Callback | symbol> | "ClassName" | "Changed" | "BreakJoints" | "MakeJoints"
 >;
 
 /** Given an Instance `T`, returns an object with methods and events filtered out. */

--- a/types/typeUtils.d.ts
+++ b/types/typeUtils.d.ts
@@ -96,7 +96,7 @@ type WritableProperties<T> = Pick<T, WritablePropertyNames<T>>;
 /** Given an Instance `T`, returns a unioned type of all property names, except "ClassName". */
 type InstancePropertyNames<T extends Instance> = Exclude<
 	keyof T,
-	FilterKeys<T, RBXScriptSignal | Callback> | "ClassName" | "Changed" | "BreakJoints" | "MakeJoints"
+	ExtractKeys<T, RBXScriptSignal | Callback> | "ClassName" | "Changed" | "BreakJoints" | "MakeJoints"
 >;
 
 /** Given an Instance `T`, returns an object with methods and events filtered out. */


### PR DESCRIPTION
### Changed
- `WritableProperties<T>`
	- renamed to `WritablePropertyNames<T>`
- `InstanceProperties<I extends Instance>`
	- renamed to `InstancePropertyNames<T extends Instance>`
- `WritableInstanceProperties<I extends Instance>`
	- now returns an object instead of keys union, alias for `WritableProperties<InstanceProperties<T>>`
- `FilterMembers<T, U>`
	- renamed to `ExtractMembers<T, U>`

### Removed
- `PresentFields<T, K extends keyof T>`
	- removed usage from @rbxts/types
- `FieldsPresentWhen<T, M extends keyof T, E extends T[M], K extends keyof T>`
	- removed usage from @rbxts/types
- `PartialProperties<T>`
	- removed in favor of `Partial<WritableProperties<T>>`
- `StrictInstances`
	- no longer necessary with removal of ClassName string unions
- `OriginalInstanceType<T extends Instance>`
	- no longer necessary with removal of ClassName string unions
- `PartialInstance<T extends Instance>`
- `GetProperties<T extends Instance>`
	- removed, was deprecated alias for InstanceProperties
- `GetWritableProperties<T extends Instance>`
	- removed, was deprecated alias for WritableInstanceProperties
- `FunctionArguments<T>`
	- removed, `Parameters<T>` serves the same purpose

### Added
- `ExcludeNominalMembers<T>`
	- returns a new object type of all the keys of T which do not start with `_nominal_`
- `ExcludeNominalKeys<T>`
	- returns a union of all keys in T that do not start with `_nominal_`
- `ExtractKeys<T, U>`
	- returns a union of all the keys of T whose values extend from U
- `ExcludeKeys<T, U>`
	- returns a union of all the keys of T whose values do not extend from U
- `ExcludeMembers<T, U>`
	- returns a new object type of all the keys of T whose values do not extend from U
- `InstanceMethodNames<T extends Instance>`
	- given an Instance `T`, returns a unioned type of all method names
- `InstanceEventNames<T extends Instance>`
	- given an Instance `T`, returns a unioned type of all event names
- `InstanceMethods<T extends Instance>`
	- given an Instance `T`, returns an object with only methods
- `InstanceEvents<T extends Instance>`
	- given an Instance `T`, returns an object with only events
