### PR TITLE
Improve Promise.all definition

### DIFF
--- a/types/Promise.d.ts
+++ b/types/Promise.d.ts
@@ -386,7 +386,7 @@ interface PromiseConstructor {
 	 * return Promise.all(promises)
 	 * ```
 	 */
-	all: <T>(promises: Array<Promise<T>>) => Promise<Array<T>>;
+	all: <T extends ReadonlyArray<unknown>>(promises: { [P in keyof T]: Promise<T[P]> }) => Promise<[...T]>;
 
 	/**
 	 * Accepts an array of Promises and returns a new Promise that resolves with an array of in-place Statuses when all input Promises have settled. This is equivalent to mapping `promise:finally` over the array of Promises.


### PR DESCRIPTION
This allows for functions such as
```ts
Promise.all<[Roact.Element, PlayerGui]>([createApp(), getPlayerGui()]).andThen(([app, playerGui]) => {

})
```
to have the correct types