### PR TITLE
Promise.fromEvent takes all of the signal's parameters

### DIFF
--- a/types/Promise.d.ts
+++ b/types/Promise.d.ts
@@ -570,12 +570,12 @@ interface PromiseConstructor {
 	 * end)
 	 * ```
 	 */
-	fromEvent<T>(this: void, event: RBXScriptSignal<(value: T) => void>, predicate?: (value: T) => boolean): Promise<T>;
+	fromEvent<T extends any[]>(this: void, event: RBXScriptSignal<(...values: T) => void>, predicate?: (...values: T) => boolean): Promise<T>;
 	fromEvent(this: void, event: RBXScriptSignal<() => void>, predicate?: () => boolean): Promise<void>;
-	fromEvent<T>(
+	fromEvent<T extends any[]>(
 		this: void,
-		event: { Connect: (callback: (value: T) => void) => void },
-		predicate?: (value: T) => boolean,
+		event: { Connect: (callback: (...values: T) => void) => void },
+		predicate?: (...values: T) => boolean,
 	): Promise<T>;
 
 	/** Checks whether the given object is a Promise via duck typing. This only checks if the object is a table and has an `andThen` method. */


### PR DESCRIPTION
Promise.fromEvent's predicate only took the first parameter from the RBXScriptSignal. Now it should take all of them. Before:
https://roblox-ts.com/playground/#code/JYWwDg9gTgLgBAbzgWQIZQNYFMZgDaoDGWAyllAG7DFwC+cAZlBCHAEQACUARgB4wBnAPQDyVYgLYBuAFAyACsxDBRAOiYsAohSwA7GAAo0mHPiKkx1LKsUswMAOKoQWeagED5AVyiEAFu5YAGLAuip+WAAmADRwBmYAnuSxAObOru4CAJIxcADu7t6+AaKRAJRwALwAfIgyAJBCQnBpLm4eOXCoupH5hT7+gb3oWHC6EPBgmVENUDg+unAwUF5YsrRlMkA

```ts
import { MarketplaceService } from "@rbxts/services";

Promise.fromEvent(MarketplaceService.PromptGamePassPurchaseFinished, (player, gamePassId, wasPurchased) => {
	// gamePassId and wasPurchased are not passed
	return true;
})
```

Now, `gamePassId` and `wasPurchased` should be passed.