### PR TITLE
Fix TS type regression

### DIFF
--- a/types/Array.d.ts
+++ b/types/Array.d.ts
@@ -123,7 +123,7 @@ interface ReadonlyArray<T> extends ArrayLike<T>, Iterable<T> {
 	/**
 	 * Removes all undefined values from the array safely
 	 */
-	filterUndefined(this: undefined extends T ? ReadonlyArray<T> : never): Array<NonNullable<T>>;
+	filterUndefined(this: ReadonlyArray<T>): Array<NonNullable<T>>;
 
 	/**
 	 * Returns the elements of an array that meet the condition specified in a callback function.

--- a/types/typeUtils.d.ts
+++ b/types/typeUtils.d.ts
@@ -44,7 +44,7 @@ type ExcludeKeys<T, U> = { [K in keyof T]: T[K] extends U ? never : K }[keyof T]
 type ExcludeMembers<T, U> = Pick<T, ExcludeKeys<T, U>>;
 
 /** Exclude null and undefined from T */
-type NonNullable<T> = unknown extends T ? defined : T extends null | undefined ? never : T;
+type NonNullable<T> = T & {};
 
 /** Obtain the parameters of a function type in a `tuple | never`. */
 type Parameters<T> = T extends (...args: infer P) => any ? P : never;


### PR DESCRIPTION
Fixes a type regression introduced by TypeScript by removing an unnecessary bound on `filterUndefined` and updating `NonNullable` to a more stable version.